### PR TITLE
US128578 - corrected exempt dependency check

### DIFF
--- a/opslevel.yml
+++ b/opslevel.yml
@@ -10,12 +10,15 @@ service:
   language: Node.js
   description:
   aliases:
+  tags:
+    - key: dependencies
+      value: exempt
   repositories:
     - name: RepublicServicesRepository/dops-github-actions
       path: '/'
       provider: github
   tools:
-  dependencies: exempt
+  dependencies:
   alert_sources:
   properties:
     additional_product_s:


### PR DESCRIPTION
After the OpsLevel scanned the config file, we discovered the way to mark a repo as exempt needed to be corrected. This update is the correction.