### PR TITLE
US128578 - update OpsLevel language, framework, and alias

### DIFF
--- a/opslevel.yml
+++ b/opslevel.yml
@@ -7,9 +7,11 @@ service:
   product: Dops GitHub Acctions
   owner: rise
   system: rise_backend
-  language: Node.js
+  language: Javascript
+  framework: Node.js
   description:
   aliases:
+    - dops-github-actions
   tags:
     - key: dependencies
       value: exempt

--- a/opslevel.yml
+++ b/opslevel.yml
@@ -12,6 +12,7 @@ service:
   description:
   aliases:
     - dops-github-actions
+    - dops_github_actions
   tags:
     - key: dependencies
       value: exempt


### PR DESCRIPTION
OpsLevel indicated 'framework' was missing from previous version of the opslevel.yml file. File has been updated.  Also added an additional alias.